### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<commons.logging.version>1.1.1</commons.logging.version>
 		<commons.cli.version>1.2</commons.cli.version>
 		<commons.cli2.version>2.0-mahout</commons.cli2.version>
-		<commons.collection.version>3.2.1</commons.collection.version>
+		<commons.collection.version>3.2.2</commons.collection.version>
 		<commons.math3.version>3.1.1</commons.math3.version>
 		<datafu.version>0.0.8</datafu.version>
 		<guava.version>13.0.1</guava.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
